### PR TITLE
Remove obsolete bitness parameter to foojay api

### DIFF
--- a/index.http
+++ b/index.http
@@ -2,4 +2,4 @@
 GET https://api.foojay.io/disco/v3.0/distributions
 
 ### get download information for a specific distribution and version
-GET https://api.foojay.io/disco/v3.0/packages?distro=graalvm_ce17&version=22.3&latest=overall&operating_system=linux&libc_type=&architecture=x64&bitness=64&archive_type=tar.gz&package_type=jdk&discovery_scope_id=directly_downloadable&match=any&javafx_bundled=false&directly_downloadable=true&release_status=ga
+GET https://api.foojay.io/disco/v3.0/packages?distro=graalvm_ce17&version=22.3&latest=overall&operating_system=linux&libc_type=&architecture=x64&archive_type=tar.gz&package_type=jdk&discovery_scope_id=directly_downloadable&match=any&javafx_bundled=false&directly_downloadable=true&release_status=ga

--- a/src/main/java/org/apache/maven/plugins/toolchain/FoojayService.java
+++ b/src/main/java/org/apache/maven/plugins/toolchain/FoojayService.java
@@ -112,7 +112,6 @@ public class FoojayService {
       archiveType = "zip";
     }
     String archName = getArchName();
-    String bitness = archName.equals("x32") ? "32" : "64";
     String libcType;
     switch (os) {
       case "linux":
@@ -133,7 +132,6 @@ public class FoojayService {
       + "&version=" + version
       + "&operating_system=" + os
       + "&architecture=" + archName
-      + "&bitness=" + bitness
       + "&archive_type=" + archiveType
       + "&libc_type=" + libcType
       + "&latest=overall&package_type=jdk&discovery_scope_id=directly_downloadable&match=any&javafx_bundled=false&directly_downloadable=true&release_status=ga";

--- a/src/test/java/org/apache/maven/plugins/toolchain/FoojayServiceTest.java
+++ b/src/test/java/org/apache/maven/plugins/toolchain/FoojayServiceTest.java
@@ -28,7 +28,7 @@ public class FoojayServiceTest {
 
     @Test
     public void testParseDownloadUrl() throws Exception {
-        final String[] jdkLoadUrl = foojayService.parseFileNameAndDownloadUrl("17", "oracle-open-jdk");
+        final String[] jdkLoadUrl = foojayService.parseFileNameAndDownloadUrl("25", "oracle-open-jdk");
         System.out.println("filename: " + jdkLoadUrl[0]);
         System.out.println("url: " + jdkLoadUrl[1]);
     }
@@ -42,6 +42,6 @@ public class FoojayServiceTest {
 
     @Test
     public void testDownloadAndExtract() throws Exception {
-        foojayService.downloadAndExtractJdk("15", "oracle_open_jdk");
+        foojayService.downloadAndExtractJdk("25", "oracle_open_jdk");
     }
 }


### PR DESCRIPTION
Our builds started failing today (03/25/2026) because the maven-toolchains-plugin (https://github.com/linux-china/toolchains-maven-plugin) failed to find any results from the foojay api. I looked through the plugin code, and it is calling the foojay api like this:

curl --location 'https://api.foojay.io/disco/v3.0/packages?distribution=corretto&version=25&operating_system=macos&architecture=x64&bitness=64&archive_type=pkg&libc_type=libc&latest=overall&package_type=jdk&discovery_scope_id=directly_downloadable&match=any&javafx_bundled=false&directly_downloadable=true&release_status=ga'

and it gets a result like this:

{ "result": [], "message": "No package(s) found" }

If I remove the bitness flag from the url manually, the search works.

curl --location 'https://api.foojay.io/disco/v3.0/packages?distribution=corretto&version=25&operating_system=macos&architecture=x64&archive_type=pkg&libc_type=libc&latest=overall&package_type=jdk&discovery_scope_id=directly_downloadable&match=any&javafx_bundled=false&directly_downloadable=true&release_status=ga'

{ "result": [ { "id": "129c97e1e7a0b10b7ca0dd01b0be2995", "archive_type": "pkg", "distribution": "corretto", "major_version": 25, "java_version": "25.0.2", "distribution_version": "25.0.2", "jdk_version": 25, "latest_build_available": true, "release_status": "ga", "term_of_support": "lts", "operating_system": "macos", "lib_c_type": "libc", "architecture": "x64", "fpu": "unknown", "package_type": "jdk", "javafx_bundled": false, "directly_downloadable": true, "filename": "amazon-corretto-25.0.2.10.1-macosx-x64.pkg", "links": { "pkg_info_uri": "https://api.foojay.io/disco/v3.0/ids/129c97e1e7a0b10b7ca0dd01b0be2995", "pkg_download_redirect": "https://api.foojay.io/disco/v3.0/ids/129c97e1e7a0b10b7ca0dd01b0be2995/redirect" }, "free_use_in_production": true, "tck_tested": "yes", "tck_cert_uri": "https://aws.amazon.com/de/blogs/opensource/amazon-corretto-no-cost-distribution-openjdk-long-term-support/", "aqavit_certified": "unknown", "aqavit_cert_uri": "", "size": 221518516, "feature": [] } ], "message": "1 package(s) found" }